### PR TITLE
Move repositories to classes and away from in-memory database

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,17 +141,6 @@
             <version>4.8.1</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
-            <version>2.3.3.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>1.4.200</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>net.iakovlev</groupId>
             <artifactId>timeshape</artifactId>
             <version>2020a.10</version>

--- a/src/main/java/com/urweather/app/backend/repository/DayInformationRepository.java
+++ b/src/main/java/com/urweather/app/backend/repository/DayInformationRepository.java
@@ -1,9 +1,34 @@
 package com.urweather.app.backend.repository;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.urweather.app.backend.entity.DayInformationEntity;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
-public interface DayInformationRepository extends JpaRepository<DayInformationEntity, Long> {
+@Repository
+public class DayInformationRepository {
 
+    private List<DayInformationEntity> repositoryOfDays = new ArrayList<>();
+
+    public void saveAll(List<DayInformationEntity> entitiesToSave) {
+        entitiesToSave.forEach(entity -> repositoryOfDays.add(entity));
+    }
+
+    public void deleteAll() {
+        repositoryOfDays.clear();
+    }
+
+    public List<DayInformationEntity> findAll() {
+        return repositoryOfDays;
+    }
+
+    public DayInformationEntity findAll(int index) {
+        return repositoryOfDays.get(index);
+    }
+
+    public int count() {
+        return repositoryOfDays.size();
+    }
 }

--- a/src/main/java/com/urweather/app/backend/repository/HourlyInformationRepository.java
+++ b/src/main/java/com/urweather/app/backend/repository/HourlyInformationRepository.java
@@ -1,10 +1,34 @@
 package com.urweather.app.backend.repository;
 
+import java.util.ArrayList;
+import java.util.List;
 
 import com.urweather.app.backend.entity.HourlyInformationEntity;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
-public interface HourlyInformationRepository extends JpaRepository<HourlyInformationEntity, Long> {
+@Repository
+public class HourlyInformationRepository {
 
+    private List<HourlyInformationEntity> repositoryOfHours = new ArrayList<>();
+
+    public void saveAll(List<HourlyInformationEntity> entitiesToSave) {
+        entitiesToSave.forEach(entity -> repositoryOfHours.add(entity));
+    }
+
+    public void deleteAll() {
+        repositoryOfHours.clear();
+    }
+
+    public List<HourlyInformationEntity> findAll() {
+        return repositoryOfHours;
+    }
+
+    public HourlyInformationEntity findAll(int index) {
+        return repositoryOfHours.get(index);
+    }
+
+    public int count() {
+        return repositoryOfHours.size();
+    }
 }

--- a/src/main/java/com/urweather/app/backend/service/DailyWeatherService.java
+++ b/src/main/java/com/urweather/app/backend/service/DailyWeatherService.java
@@ -30,10 +30,10 @@ public class DailyWeatherService {
     private final String API_KEY = "jZdP0f1KuUvdEIrQPLomXIQGdutw9mI1";
 
     @Autowired
-    private DayInformationRepository dayInformationRepository;
+    private DayInformationRepository dayInformationRepo;
 
-    public DailyWeatherService(DayInformationRepository dayInformationRepository) {
-        this.dayInformationRepository = dayInformationRepository;
+    public DailyWeatherService(DayInformationRepository dayInformationRepo) {
+        this.dayInformationRepo = dayInformationRepo;
     }
 
 
@@ -53,19 +53,19 @@ public class DailyWeatherService {
     }
 
     public List<DayInformationEntity> getListOfDailyWeatherEntities(int total) {
-        return dayInformationRepository.findAll().stream().limit(total)
+        return dayInformationRepo.findAll().stream().limit(total)
                 .collect(Collectors.toList());
     }
 
     public DayInformationEntity getFirstDayWeatherEntity() {
-        return dayInformationRepository.findAll().get(0);
+        return dayInformationRepo.findAll(0);
     }
 
     private void addDailyWeatherEntityToRepository(List<DayInformationEntity> listOfDays) {
-        if(dayInformationRepository.count() != 0) {
-            dayInformationRepository.deleteAll();
+        if(dayInformationRepo.count() != 0) {
+            dayInformationRepo.deleteAll();
         }
-        dayInformationRepository.saveAll(listOfDays);
+        dayInformationRepo.saveAll(listOfDays);
     }
 
     private List<DayInformationEntity> parseBodyAndReturnDayInformationEntity(ResponseBody responseBody,

--- a/src/main/java/com/urweather/app/backend/service/HourlyWeatherService.java
+++ b/src/main/java/com/urweather/app/backend/service/HourlyWeatherService.java
@@ -33,10 +33,10 @@ public class HourlyWeatherService {
     private final String API_KEY = "jZdP0f1KuUvdEIrQPLomXIQGdutw9mI1";
 
     @Autowired
-    private HourlyInformationRepository hourlyInformationRepository;
+    private HourlyInformationRepository hourlyInformationRepo;
 
-    private HourlyWeatherService(HourlyInformationRepository hourlyInformationRepository) {
-        this.hourlyInformationRepository = hourlyInformationRepository;
+    private HourlyWeatherService(HourlyInformationRepository hourlyInformationRep) {
+        this.hourlyInformationRepo = hourlyInformationRep;
     }
 
     public void createHourlyWeatherInformation(GeoLocationObject geoLocation) throws NullPointerException, IOException {
@@ -56,18 +56,18 @@ public class HourlyWeatherService {
     }
 
     public HourlyInformationEntity getFirstHourInformation() {
-        return hourlyInformationRepository.findAll().get(0);
+        return hourlyInformationRepo.findAll(0);
     }
 
     public List<HourlyInformationEntity> getListOfHourlyInformation() {
-        return hourlyInformationRepository.findAll();
+        return hourlyInformationRepo.findAll();
     }
 
     private void addHourlyInformationToRepository(List<HourlyInformationEntity> listOfHourEntities) {
-        if(hourlyInformationRepository.count() != 0) {
-            hourlyInformationRepository.deleteAll();
+        if(hourlyInformationRepo.count() != 0) {
+            hourlyInformationRepo.deleteAll();
         }
-        hourlyInformationRepository.saveAll(listOfHourEntities);
+        hourlyInformationRepo.saveAll(listOfHourEntities);
     }
 
     private List<HourlyInformationEntity> parseAndReturnListOfHourlyEntities(ResponseBody responseBody) throws JsonSyntaxException, IOException {


### PR DESCRIPTION
Instead of using H2 in-memory database, I moved to a regular class. H2 in-memory database would not work exactly how I want during deployment. H2 relies on an SQL database format which is not really needed.