### PR TITLE
Removes timezone conversion for days of the week.

### DIFF
--- a/src/main/java/com/urweather/app/helpers/TimezoneConvertorHelper.java
+++ b/src/main/java/com/urweather/app/helpers/TimezoneConvertorHelper.java
@@ -20,11 +20,4 @@ public class TimezoneConvertorHelper {
         return zoneId.map(zone -> pointInTime.atZone(zone))
                 .orElse(null);
     }
-
-    public final static Date addZoneDateHoursToGivenDate(Date startDate) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTime(startDate);
-        calendar.add(Calendar.HOUR_OF_DAY,  ZonedDateTime.now().getHour());
-        return calendar.getTime();
-    }
  }

--- a/src/main/java/com/urweather/app/ui/views/DailyWeatherSnippetView.java
+++ b/src/main/java/com/urweather/app/ui/views/DailyWeatherSnippetView.java
@@ -1,14 +1,12 @@
 package com.urweather.app.ui.views;
 
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 
 import com.urweather.app.backend.entity.DayInformationEntity;
 import com.urweather.app.backend.service.DailyWeatherService;
 import com.urweather.app.helpers.ImageIconHelper;
-import com.urweather.app.helpers.TimezoneConvertorHelper;
 import com.vaadin.flow.spring.annotation.UIScope;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,11 +33,9 @@ public class DailyWeatherSnippetView extends AbstractWeatherSnippetView {
         deleteAllCurrentSnippets();
 
         listOfDays.forEach(day -> {
-            Date addHoursDate = TimezoneConvertorHelper.addZoneDateHoursToGivenDate(day.getObservationTime());
-            ZonedDateTime convertedDate = TimezoneConvertorHelper.convertDateToLocalTimezone(day.getLat(),
-                                                day.getLon(), addHoursDate);
-            DateTimeFormatter dateFormat =  DateTimeFormatter.ofPattern("EE");
-            String time = convertedDate.format(dateFormat).toUpperCase();
+            Date addHoursDate = day.getObservationTime();
+            SimpleDateFormat formatter = new SimpleDateFormat("E");
+            String time = formatter.format(addHoursDate).toUpperCase();
             String temp = Math.round(day.getMax()) + DEGREE + "/" + Math.round(day.getMin()) + DEGREE;
             String imageSrc = ImageIconHelper.getPathOfIconFromWeatherCode(day.getWeatherCode());
             addWeatherSnippet(time, imageSrc, temp);


### PR DESCRIPTION
Timezone conversion is no longer needed for the daily weather since the API accounts for the timezone difference and changes the observed_time accordingly. Now it uses the observed_time for the day of the week formatting. 