### PR TITLE
Move callService() functionality to AbstractService

### DIFF
--- a/src/main/java/com/urweather/app/backend/service/AbstractService.java
+++ b/src/main/java/com/urweather/app/backend/service/AbstractService.java
@@ -10,16 +10,25 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import okhttp3.HttpUrl.Builder;
 
 import static com.urweather.app.helpers.ServicesConstants.VALUE;
 
-public abstract class AbstractService<T, E, G> {
+public abstract class AbstractService<T, E> {
 
-    abstract public void callService(T type) throws JsonSyntaxException, IOException, NullPointerException;
+    abstract protected void storeEntityInChosenLocaion(E entity);
 
     abstract protected E parseResponseBody(ResponseBody responseBody) throws JsonSyntaxException, IOException;
 
-    abstract protected HttpUrl.Builder createUrlBuilder(G object);
+    abstract protected HttpUrl.Builder createUrlBuilder(T object);
+
+    public void callService(T type) throws JsonSyntaxException, IOException, NullPointerException {
+        Builder urlBuilder = createUrlBuilder(type);
+        ResponseBody responseBody = callRequestAndReturnResponseBody(urlBuilder);
+        E parsedEntity = parseResponseBody(responseBody);
+
+        storeEntityInChosenLocaion(parsedEntity);
+    }
 
     protected JsonElement getValueFromElement(JsonElement element) {
         return element.getAsJsonObject().get(VALUE);

--- a/src/main/java/com/urweather/app/backend/service/DailyWeatherService.java
+++ b/src/main/java/com/urweather/app/backend/service/DailyWeatherService.java
@@ -24,23 +24,13 @@ import okhttp3.HttpUrl;
 import okhttp3.ResponseBody;
 
 @Service
-public class DailyWeatherService extends AbstractService<GeoLocationEntity, List<DayInformationEntity>, GeoLocationEntity> {
+public class DailyWeatherService extends AbstractService<GeoLocationEntity, List<DayInformationEntity>> {
 
     @Autowired
     private DayInformationRepository dayInformationRepo;
 
     public DailyWeatherService(DayInformationRepository dayInformationRepo) {
         this.dayInformationRepo = dayInformationRepo;
-    }
-
-    @Override
-    public final void callService(GeoLocationEntity geoLocation) throws IOException {
-        HttpUrl.Builder urlBuilder = createUrlBuilder(geoLocation);
-
-        ResponseBody responseBody = callRequestAndReturnResponseBody(urlBuilder);
-
-        List<DayInformationEntity> listOfDayEntities = parseResponseBody(responseBody);
-        addDailyWeatherEntityToRepository(listOfDayEntities);
     }
 
     @Override
@@ -65,6 +55,11 @@ public class DailyWeatherService extends AbstractService<GeoLocationEntity, List
                 .addQueryParameter("start_time", "now")
                 .addQueryParameter("fields", APIConstants.DAILY_FIELDS)
                 .addQueryParameter("apikey", APIConstants.CLIMACELL_API_KEY);
+    }
+
+    @Override
+    protected void storeEntityInChosenLocaion(List<DayInformationEntity> entity) {
+        addDailyWeatherEntityToRepository(entity);
     }
 
     public List<DayInformationEntity> getListOfDailyWeatherEntities(int total) {

--- a/src/main/java/com/urweather/app/backend/service/DetailWeatherService.java
+++ b/src/main/java/com/urweather/app/backend/service/DetailWeatherService.java
@@ -16,18 +16,9 @@ import okhttp3.HttpUrl;
 import okhttp3.ResponseBody;
 
 @Service
-public class DetailWeatherService extends AbstractService<GeoLocationEntity, DetailWeatherEntity, GeoLocationEntity> {
+public class DetailWeatherService extends AbstractService<GeoLocationEntity, DetailWeatherEntity> {
 
     private static DetailWeatherEntity currentDetailWeatherInformation;
-
-    @Override
-    public void callService(GeoLocationEntity geoLocation) throws JsonSyntaxException, IOException, NullPointerException {
-        HttpUrl.Builder urlBuilder = createUrlBuilder(geoLocation);
-
-        ResponseBody responseBody = callRequestAndReturnResponseBody(urlBuilder);
-
-        currentDetailWeatherInformation = parseResponseBody(responseBody);
-    }
 
     @Override
     protected DetailWeatherEntity parseResponseBody(ResponseBody responseBody) throws JsonSyntaxException, IOException {
@@ -54,6 +45,11 @@ public class DetailWeatherService extends AbstractService<GeoLocationEntity, Det
                 .addQueryParameter(APIConstants.UNIT_SYSTEM, APIConstants.SI)
                 .addQueryParameter("fields", APIConstants.DETAILS_FIELDS)
                 .addQueryParameter("apikey", APIConstants.CLIMACELL_API_KEY);
+    }
+
+    @Override
+    protected void storeEntityInChosenLocaion(DetailWeatherEntity entity) {
+        currentDetailWeatherInformation = entity;
     }
 
     public DetailWeatherEntity getDetailWeatherInformation() {

--- a/src/main/java/com/urweather/app/backend/service/GeoLocationService.java
+++ b/src/main/java/com/urweather/app/backend/service/GeoLocationService.java
@@ -25,20 +25,9 @@ import static com.urweather.app.helpers.APIConstants.GEOLOCATION_SCHEME;
 import static com.urweather.app.helpers.APIConstants.GEOLOCATION_VERSION;
 
 @Service
-public class GeoLocationService extends AbstractService<String, GeoLocationEntity, String[]>{
+public class GeoLocationService extends AbstractService<String[], GeoLocationEntity>{
 
     private static GeoLocationEntity currentGeoLocation;
-
-    @Override
-    public final void callService(String userInput) throws JsonSyntaxException, IOException, NullPointerException {
-        String[] splitUserInput = parseAndReturnCityAndCountry(userInput);
-
-        HttpUrl.Builder urlBuilder = createUrlBuilder(splitUserInput);
-
-        ResponseBody responseBody = callRequestAndReturnResponseBody(urlBuilder);
-
-        currentGeoLocation = parseResponseBody(responseBody);
-    }
 
     @Override
     protected GeoLocationEntity parseResponseBody(ResponseBody responseBody) throws JsonSyntaxException, IOException {
@@ -75,15 +64,12 @@ public class GeoLocationService extends AbstractService<String, GeoLocationEntit
         return response.body();
     }
 
-    public GeoLocationEntity getCurrentGeoLocation() {
-        return currentGeoLocation;
+    @Override
+    protected void storeEntityInChosenLocaion(GeoLocationEntity entity) {
+        currentGeoLocation = entity;
     }
 
-    private String[] parseAndReturnCityAndCountry(String userInput) throws InputMismatchException {
-        String[] splitInput = userInput.split(",");
-        if(splitInput.length != 2) {
-            throw new InputMismatchException("Please make sure input is in similar format to, 'Richmond Hill, CA'");
-        }
-        return splitInput;
+    public GeoLocationEntity getCurrentGeoLocation() {
+        return currentGeoLocation;
     }
 }

--- a/src/main/java/com/urweather/app/backend/service/GeoLocationService.java
+++ b/src/main/java/com/urweather/app/backend/service/GeoLocationService.java
@@ -2,7 +2,6 @@ package com.urweather.app.backend.service;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.util.InputMismatchException;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;

--- a/src/main/java/com/urweather/app/backend/service/HourlyWeatherService.java
+++ b/src/main/java/com/urweather/app/backend/service/HourlyWeatherService.java
@@ -27,8 +27,7 @@ import okhttp3.HttpUrl;
 import okhttp3.ResponseBody;
 
 @Service
-public class HourlyWeatherService
-        extends AbstractService<GeoLocationEntity, List<HourlyInformationEntity>, GeoLocationEntity> {
+public class HourlyWeatherService extends AbstractService<GeoLocationEntity, List<HourlyInformationEntity>> {
 
 
     @Autowired
@@ -36,16 +35,6 @@ public class HourlyWeatherService
 
     private HourlyWeatherService(HourlyInformationRepository hourlyInformationRep) {
         this.hourlyInformationRepo = hourlyInformationRep;
-    }
-
-    @Override
-    public void callService(GeoLocationEntity geoLocation) throws JsonSyntaxException, IOException, NullPointerException {
-        HttpUrl.Builder urlBuilder = createUrlBuilder(geoLocation);
-
-        ResponseBody responseBody = callRequestAndReturnResponseBody(urlBuilder);
-
-        List<HourlyInformationEntity> listOfHourlyEntities = parseResponseBody(responseBody);
-        addHourlyInformationToRepository(listOfHourlyEntities);
     }
 
     @Override
@@ -74,6 +63,11 @@ public class HourlyWeatherService
                 .addQueryParameter("end_time", formatter.format(futureEndTime))
                 .addQueryParameter("fields", APIConstants.HOURLY_FIELDS)
                 .addQueryParameter("apikey", APIConstants.CLIMACELL_API_KEY);
+    }
+
+    @Override
+    protected void storeEntityInChosenLocaion(List<HourlyInformationEntity> entity) {
+        addHourlyInformationToRepository(entity);
     }
 
     public List<HourlyInformationEntity> getListOfHourlyInformation() {

--- a/src/main/java/com/urweather/app/backend/service/NowcastWeatherService.java
+++ b/src/main/java/com/urweather/app/backend/service/NowcastWeatherService.java
@@ -16,18 +16,9 @@ import okhttp3.HttpUrl;
 import okhttp3.ResponseBody;
 
 @Service
-public class NowcastWeatherService extends AbstractService<GeoLocationEntity, NowcastWeatherEntity, GeoLocationEntity> {
+public class NowcastWeatherService extends AbstractService<GeoLocationEntity, NowcastWeatherEntity> {
 
     private static NowcastWeatherEntity currentNowcastInformation;
-
-    @Override
-    public void callService(GeoLocationEntity geoLocationObject) throws JsonSyntaxException, IOException {
-        HttpUrl.Builder urlBuilder = createUrlBuilder(geoLocationObject);
-
-        ResponseBody responseBody = callRequestAndReturnResponseBody(urlBuilder);
-
-        currentNowcastInformation = parseResponseBody(responseBody);
-    }
 
     @Override
     protected NowcastWeatherEntity parseResponseBody(ResponseBody responseBody) throws JsonSyntaxException, IOException {
@@ -54,6 +45,11 @@ public class NowcastWeatherService extends AbstractService<GeoLocationEntity, No
                 .addQueryParameter(APIConstants.UNIT_SYSTEM, APIConstants.SI)
                 .addQueryParameter("fields", APIConstants.NOWCAST_FIELDS)
                 .addQueryParameter("apikey", APIConstants.CLIMACELL_API_KEY);
+    }
+
+    @Override
+    protected void storeEntityInChosenLocaion(NowcastWeatherEntity entity) {
+        currentNowcastInformation = entity;
     }
 
     public NowcastWeatherEntity getCurreNowcastObject() {

--- a/src/main/java/com/urweather/app/helpers/TimezoneConvertorHelper.java
+++ b/src/main/java/com/urweather/app/helpers/TimezoneConvertorHelper.java
@@ -3,7 +3,6 @@ package com.urweather.app.helpers;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.Optional;
 

--- a/src/main/java/com/urweather/app/ui/views/NavigationView.java
+++ b/src/main/java/com/urweather/app/ui/views/NavigationView.java
@@ -1,6 +1,8 @@
 package com.urweather.app.ui.views;
 
 import java.io.IOException;
+import java.util.InputMismatchException;
+
 import javax.annotation.PostConstruct;
 
 import com.google.gson.JsonSyntaxException;
@@ -74,7 +76,8 @@ public class NavigationView extends Header {
 
     private void addButtonEvent() {
         searchButton.addClickListener(event -> {
-            GeoLocationEntity geoLocation = callGeoLocationService(searchField.getValue());
+            String[] geoLocationInfo = splitStringIntoCityAndCountry(searchField.getValue());
+            GeoLocationEntity geoLocation = callGeoLocationService(geoLocationInfo);
             if (geoLocation != null) {
                 boolean didDailyServiceWork = callWeatherService(dailyWeatherService, geoLocation);
                 boolean didHourlyServiceWork = callWeatherService(hourlyWeatherService, geoLocation);
@@ -102,15 +105,22 @@ public class NavigationView extends Header {
 		}
     }
 
-    private GeoLocationEntity callGeoLocationService(String location) {
+    private GeoLocationEntity callGeoLocationService(String[] location) {
         try {
             geoLocationService.callService(location);
-            GeoLocationEntity geoLocation = geoLocationService.getCurrentGeoLocation();
-            return geoLocation;
+            return geoLocationService.getCurrentGeoLocation();
         } catch (Exception e) {
             Notification.show(e.toString());
             return null;
         }
+    }
+
+    private String[] splitStringIntoCityAndCountry(String userInput) throws InputMismatchException {
+        String[] splitInput = userInput.split(",");
+        if(splitInput.length != 2) {
+            throw new InputMismatchException("Please make sure input is in similar format to, 'Richmond Hill, CA'");
+        }
+        return splitInput;
     }
 
     public Registration addTodayUpdatedListener(ComponentEventListener<UpdateTodayWeatherEvent> listener) {

--- a/src/test/java/com/urweather/app/backend/service/DailyWeatherServiceTest.java
+++ b/src/test/java/com/urweather/app/backend/service/DailyWeatherServiceTest.java
@@ -39,7 +39,7 @@ public class DailyWeatherServiceTest {
     public void creatGeoLocationAndCallDailyService() {
         GeoLocationEntity geoLocationObj = new GeoLocationEntity();
         try {
-            geoLocationService.callService("Richmond Hill, CA");
+            geoLocationService.callService(new String[]{"Richmond Hill", "CA"});
             geoLocationObj = geoLocationService.getCurrentGeoLocation();
             dailyWeatherService.callService(geoLocationObj);
         } catch (JsonSyntaxException | InputMismatchException | IndexOutOfBoundsException | IOException e) {

--- a/src/test/java/com/urweather/app/backend/service/GeoLocationServiceTest.java
+++ b/src/test/java/com/urweather/app/backend/service/GeoLocationServiceTest.java
@@ -24,7 +24,7 @@ public class GeoLocationServiceTest {
     public void properGeoLocationObjectCreated() {
         GeoLocationEntity receviedObject = new GeoLocationEntity();
         try {
-            geoLocationService.callService("Richmond Hill, CA");
+            geoLocationService.callService(new String[]{"Richmond Hill", "CA"});
             receviedObject = geoLocationService.getCurrentGeoLocation();
         } catch (JsonSyntaxException | InputMismatchException | IndexOutOfBoundsException | IOException e) {
             Assert.fail(e.getMessage());

--- a/src/test/java/com/urweather/app/backend/service/HourlyWeatherServiceTest.java
+++ b/src/test/java/com/urweather/app/backend/service/HourlyWeatherServiceTest.java
@@ -40,7 +40,7 @@ public class HourlyWeatherServiceTest {
     public void createGeoLocationAndCallHourlyService() {
         GeoLocationEntity geoLocationObj = new GeoLocationEntity();
         try {
-            geoLocationService.callService("Richmond Hill, CA");
+            geoLocationService.callService(new String[]{"Richmond Hill", "CA"});
             geoLocationObj = geoLocationService.getCurrentGeoLocation();
             hourlyWeatherService.callService(geoLocationObj);
         } catch (JsonSyntaxException | InputMismatchException | IndexOutOfBoundsException | IOException e) {


### PR DESCRIPTION
The callService() functionality is now all in the AbstractService and the Service just needs to implement their own way of storing the entities that were created.

**Note:** This move also resulted in the need to move the input splitting to the NavigationView instead of being in the GeoLocationService.